### PR TITLE
Update nametag3_client.py to keep the original newlines in input files.

### DIFF
--- a/nametag3_client.py
+++ b/nametag3_client.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         for input_path in (args.inputs or [sys.stdin]):
             # Use stdin if no inputs are specified
             if input_path != sys.stdin:
-                with open(input_path, "r", encoding="utf-8-sig") as input_file:
+                with open(input_path, "r", encoding="utf-8-sig", newline="") as input_file:
                     data = input_file.read()
             else:
                 data = sys.stdin.read()

--- a/nametag3_client.py
+++ b/nametag3_client.py
@@ -65,11 +65,9 @@ commandlind-line arguments below.
 
 
 import argparse
-import email.mime.multipart
-import email.mime.nonmultipart
-import email.policy
 import json
 import os
+import random
 import sys
 import urllib.error
 import urllib.request
@@ -79,17 +77,20 @@ def perform_request(server, method, params={}):
     if not params:
         request_headers, request_data = {}, None
     else:
-        message = email.mime.multipart.MIMEMultipart("form-data", policy=email.policy.HTTP)
-
+        boundary = "{:x}".format(random.getrandbits(50 * 4))
+        request_headers = {"Content-Type": "multipart/form-data; boundary=\"{}\"".format(boundary)}
+        request_data = []
         for name, value in params.items():
-            payload = email.mime.nonmultipart.MIMENonMultipart("text", "plain")
-            payload.add_header("Content-Disposition", "form-data; name=\"{}\"".format(name))
-            payload.add_header("Content-Transfer-Encoding", "8bit")
-            payload.set_payload(value, charset="utf-8")
-            message.attach(payload)
-
-        request_data = message.as_bytes().replace(b"\r\n", b"\n").split(b"\n\n", maxsplit=1)[1]
-        request_headers = {"Content-Type": message["Content-Type"]}
+            request_data.extend([
+                "--" + boundary,
+                "Content-Disposition: form-data; name=\"{}\"".format(name),
+                "Content-Transfer-Encoding: 8bit",
+                "Content-Type: text/plain; charset=utf-8",
+                "",
+                value,
+            ])
+        request_data.extend(["--" + boundary + "--", ""])
+        request_data = "\r\n".join(request_data).encode("utf-8")
 
     try:
         with urllib.request.urlopen(urllib.request.Request(


### PR DESCRIPTION
- Replace the form-data email.mime* calls with manual implementation.
    
  The email.mime* implementation always replaces newlines with CRLF (or the chosen sep, but only CRLF is valid in MIME), even inside the objects (if they are for example binary data), which changes the line endings in the files sent to the NameTag service.
    
  The new implementation keeps the line separators from the original file. That does not violate MIME spec, because the "protocol-level" line endings are still CRLF.

- Keep the original line endings when loading from the input files.